### PR TITLE
PIA-1023: Introduce shadowsucks-rust submodule and gradle dependency

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -4,12 +4,19 @@ jobs:
   build-android:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: prepare rust targets
+        run: rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
       - name: build
         run: ./gradlew assembleDebug assembleRelease --info --parallel
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/lint-android.yaml
+++ b/.github/workflows/lint-android.yaml
@@ -4,11 +4,18 @@ jobs:
   lint-android:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: prepare rust targets
+        run: rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
       - name: lint
         run: ./gradlew ktlintCheck

--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -4,11 +4,18 @@ jobs:
   unit-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: prepare rust targets
+        run: rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
       - name: unit-tests
         run: ./gradlew test --parallel

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "obfuscator/shadowsocks/src/main/rust/shadowsocks-rust"]
+	path = obfuscator/shadowsocks/src/main/rust/shadowsocks-rust
+	url = git@github.com:shadowsocks/shadowsocks-rust.git

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     id("com.android.library") version "8.2.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.10" apply false
     id("org.jlleitschuh.gradle.ktlint") version "11.5.1" apply false
+    id("org.mozilla.rust-android-gradle.rust-android") version "0.9.3" apply false
 }

--- a/obfuscator/build.gradle.kts
+++ b/obfuscator/build.gradle.kts
@@ -42,4 +42,5 @@ android {
 }
 
 dependencies {
+    implementation(project(":obfuscator:shadowsocks"))
 }

--- a/obfuscator/shadowsocks/.gitignore
+++ b/obfuscator/shadowsocks/.gitignore
@@ -1,0 +1,37 @@
+# Gradle files
+.gradle/
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Log/OS Files
+*.log
+.DS_Store
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+output.json
+
+# IntelliJ
+*.iml
+.idea/
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Android Profiling
+*.hprof
+
+# System
+*.DS_Store

--- a/obfuscator/shadowsocks/build.gradle.kts
+++ b/obfuscator/shadowsocks/build.gradle.kts
@@ -1,0 +1,72 @@
+import org.gradle.kotlin.dsl.support.listFilesOrdered
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("org.mozilla.rust-android-gradle.rust-android")
+}
+
+android {
+    namespace = "com.kape.obfuscator.shadowsocks"
+    ndkVersion = sdkDirectory.resolve("ndk").listFilesOrdered().last().name
+
+    compileSdk = 34
+    defaultConfig {
+        minSdk = 24
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+}
+
+cargo {
+    module = "src/main/rust/shadowsocks-rust"
+    libname = "sslocal"
+    targets = listOf("arm", "arm64", "x86", "x86_64")
+    profile = "release"
+    extraCargoBuildArguments = listOf("--bin", libname!!)
+    features {
+        noDefaultBut(
+            arrayOf(
+                "logging",
+                "local-dns",
+                "local-tun",
+                "aead-cipher-2022"
+            )
+        )
+    }
+    exec = { spec, toolchain ->
+        run {
+            try {
+                Runtime.getRuntime().exec("python3 -V >/dev/null 2>&1")
+                spec.environment("RUST_ANDROID_GRADLE_PYTHON_COMMAND", "python3")
+            } catch (e: java.io.IOException) {
+                throw GradleException("Please install Python3 in order to compile.")
+            }
+            spec.environment("RUST_ANDROID_GRADLE_LINKER_WRAPPER_PY", "$projectDir/$module/../linker-wrapper.py")
+            spec.environment("RUST_ANDROID_GRADLE_TARGET", "target/${toolchain.target}/$profile/lib$libname.so")
+        }
+    }
+}
+
+tasks.whenTaskAdded {
+    if (this.name == "javaPreCompileDebug" || this.name == "javaPreCompileRelease") {
+        this.dependsOn("cargoBuild")
+    }
+}
+
+dependencies {
+}

--- a/obfuscator/shadowsocks/src/main/AndroidManifest.xml
+++ b/obfuscator/shadowsocks/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+</manifest>

--- a/obfuscator/shadowsocks/src/main/rust/linker-wrapper.py
+++ b/obfuscator/shadowsocks/src/main/rust/linker-wrapper.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import os
+import pipes
+import shutil
+import subprocess
+import sys
+
+rustcc = os.environ['RUST_ANDROID_GRADLE_CC']
+
+if sys.platform == 'msys' or sys.platform == 'cygwin':
+    import ctypes
+
+    cygdll = 'cygwin1.dll' if sys.platform == 'cygwin' else 'msys-2.0.dll'
+    cygwin = ctypes.cdll.LoadLibrary(cygdll)
+
+    def win2posix(path):
+        CCP_WIN_W_TO_POSIX = 3
+        size = cygwin.cygwin_conv_path(CCP_WIN_W_TO_POSIX, path, 0, 0)
+        retval = ctypes.create_string_buffer(size)
+        cygwin.cygwin_conv_path(CCP_WIN_W_TO_POSIX, path, retval, size)
+        return retval.value.decode()
+
+    rustcc = win2posix(rustcc)
+
+args = [rustcc, os.environ['RUST_ANDROID_GRADLE_CC_LINK_ARG']] + sys.argv[1:]
+
+def update_in_place(arglist):
+    # The `gcc` library is not included starting from NDK version 23.
+    # Work around by using `unwind` replacement.
+    ndk_major_version = os.environ["CARGO_NDK_MAJOR_VERSION"]
+    if ndk_major_version.isdigit():
+        if 23 <= int(ndk_major_version):
+            for i, arg in enumerate(arglist):
+                if arg.startswith("-lgcc"):
+                    # This is one way to preserve line endings.
+                    arglist[i] = "-lunwind" + arg[len("-lgcc") :]
+
+
+update_in_place(args)
+
+for arg in args:
+    if arg.startswith("@"):
+        fileargs = open(arg[1:], "r").read().splitlines(keepends=True)
+        update_in_place(fileargs)
+        open(arg[1:], "w").write("".join(fileargs))
+
+linkargfileName = ''
+if (sys.platform == 'msys' or sys.platform == 'cygwin') and len(''.join(args)) > 8191:
+    import codecs
+    import tempfile
+
+    def posix2win(path):
+        CCP_POSIX_TO_WIN_W = 1
+        size = cygwin.cygwin_conv_path(CCP_POSIX_TO_WIN_W, str(path).encode(), 0, 0)
+        retval = ctypes.create_unicode_buffer(size)
+        cygwin.cygwin_conv_path(CCP_POSIX_TO_WIN_W, str(path).encode(), retval, size)
+        return retval.value
+
+    # response file should be use UTF-16 with BOM
+    linkargfile = tempfile.NamedTemporaryFile(delete=False)
+    linkargfile.write(codecs.BOM_UTF16_LE)
+    linkargfile.write('\n'.join(sys.argv[1:]).encode('utf-16-le'))
+    linkargfile.close()
+    linkargfileName = linkargfile.name
+    linkargfileNameW = posix2win(linkargfileName)
+    args = [rustcc, os.environ['RUST_ANDROID_GRADLE_CC_LINK_ARG'], '@' + linkargfileNameW]
+
+
+# This only appears when the subprocess call fails, but it's helpful then.
+printable_cmd = " ".join(pipes.quote(arg) for arg in args)
+print(printable_cmd)
+
+code = subprocess.call(args)
+if code == 0:
+    sys_argv = sys.argv
+    if sys.platform == 'msys' or sys.platform == 'cygwin' or sys.platform == 'win32':
+        linkargs = list(filter(lambda s: s.startswith('@') and s.find('linker-arguments') != -1, sys.argv[1:]))
+        if linkargs != []:
+            with open(linkargs[0][1:]) as f:
+                sys_argv = f.read().splitlines()
+    shutil.copyfile(sys_argv[sys_argv.index('-o') + 1], os.environ['RUST_ANDROID_GRADLE_TARGET'])
+if linkargfileName != '':
+    os.unlink(linkargfileName)
+sys.exit(code)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,4 +17,5 @@ dependencyResolutionManagement {
 
 include(":testapp")
 include(":obfuscator")
+include(":obfuscator:shadowsocks")
  

--- a/testapp/build.gradle.kts
+++ b/testapp/build.gradle.kts
@@ -32,7 +32,6 @@ android {
 }
 
 dependencies {
-
     implementation(project(":obfuscator"))
 
     implementation("androidx.core:core-ktx:1.12.0")


### PR DESCRIPTION
## Summary

- It introduces the `shadowsocks` module.
- It introduces the submodule for `shadowsocks-rust` within the `shadowsocks` module.
- It introduces the cargo gradle plugin to compile the rust submodule within the `shadowsocks` module.

## Sanity Tests

- [x] Compile. Confirm `libsslocal.so` is generated for each architecture within the `build` folder.