### PR TITLE
PIA-1289: Include stream ciphers

### DIFF
--- a/obfuscator/build.gradle.kts
+++ b/obfuscator/build.gradle.kts
@@ -52,7 +52,9 @@ cargo {
                 "logging",
                 "local-dns",
                 "local-tun",
-                "aead-cipher-2022"
+                "stream-cipher",
+                "aead-cipher-2022",
+                "aead-cipher-extra"
             )
         )
     }

--- a/testapp/build.gradle.kts
+++ b/testapp/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.kape.testapp"
+        applicationId = "com.kape.obfuscator.testapp"
         minSdk = 24
         targetSdk = 34
         versionCode = 1


### PR DESCRIPTION
## Summary

As per the title, it includes the `stream-ciphers` and `aead-cipher-extra` as we have some servers setup with those.

## Sanity Tests

- [x] Using a local deployment with these changes. Confirm we can connect to those specific servers.