### PR TITLE
PIA-XXXX: Include tunnel feature to the library

### DIFF
--- a/obfuscator/build.gradle.kts
+++ b/obfuscator/build.gradle.kts
@@ -49,6 +49,7 @@ cargo {
     features {
         noDefaultBut(
             arrayOf(
+                "local-tunnel",
                 "logging",
                 "local-dns",
                 "local-tun",


### PR DESCRIPTION
## Summary

It includes the `local-tunnel` feature to the library to allow for the user of the tunnel protocol.

## Sanity Tests

- [x] Include a version of the library with the changes. Start the library using `--protocol tunnel`. Confirm it starts successfully.